### PR TITLE
docs: fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![LambdaTest Logo](https://www.lambdatest.com/static/images/logo.svg)
+![LambdaTest Logo](https://www.lambdatest.com/resources/images/logos/logo.svg)
 ---
 
 # Nodejs Cucumber todo List


### PR DESCRIPTION
The LambdaTest logo link was broken in the [README.md](https://github.com/LambdaTest/nodejs-cucumber-todo/blob/0553801b0b62dd03ffc8a39b42e2ab1a05774d72/README.md). This PR fixes that.