### PR TITLE
Migrate sample To-Do app to testmuai.com

### DIFF
--- a/features/todo.feature
+++ b/features/todo.feature
@@ -1,8 +1,8 @@
 Feature: Automate a website
     Scenario: perform click events
-      When visit url "https://lambdatest.github.io/sample-todo-app"
+      When visit url "https://www.testmuai.com/selenium-playground/todo-app/"
       When field with name "First Item" is present check the box
       When field with name "Second Item" is present check the box
       When select the textbox add "Let's add new to do item" in the box
       Then click the "addbutton"
-      Then I must see title "Modern To-Do App | LambdaTest"
+      Then I must see title "Selenium Grid Online | Run Selenium Test On Cloud"


### PR DESCRIPTION
### What
The LambdaTest sample To-Do app at `https://lambdatest.github.io/sample-todo-app/` has been **deprecated** and replaced by `https://www.testmuai.com/selenium-playground/todo-app/`. This PR points the tests at the new app.

### Why it's more than a URL swap
The new app is a **React** port of the old **AngularJS** app. Stable hooks are preserved — `#sampletodotext`, `#addbutton`, checkbox `name="li1".."liN"`, and added items still get sequential `li6/li7/...` names. But a few things changed, so the affected selectors/assertions were updated and **validated against the live new app**:
- Page `<title>` is now `Selenium Grid Online | Run Selenium Test On Cloud` (was `Modern To-Do App | LambdaTest`).
- Angular `ng-model`/`ng-repeat` attributes are gone → replaced with id/name/class selectors.
- `ul.list-unstyled` class and absolute XPaths like `/html/body/div/div/div/ul/li[N]/span` no longer match the new DOM → replaced with robust relative locators (e.g. `//input[@name='li6']/following-sibling::span`).

### Changes in this repo
```diff
diff --git a/features/todo.feature b/features/todo.feature
index c96f4f9..bd34f6c 100644
--- a/features/todo.feature
+++ b/features/todo.feature
@@ -1,8 +1,8 @@
 Feature: Automate a website
     Scenario: perform click events
-      When visit url "https://lambdatest.github.io/sample-todo-app"
+      When visit url "https://www.testmuai.com/selenium-playground/todo-app/"
       When field with name "First Item" is present check the box
       When field with name "Second Item" is present check the box
       When select the textbox add "Let's add new to do item" in the box
       Then click the "addbutton"
-      Then I must see title "Modern To-Do App | LambdaTest"
\ No newline at end of file
+      Then I must see title "Selenium Grid Online | Run Selenium Test On Cloud"
\ No newline at end of file
```

> Note: the new page's `<title>` looks like it may be inheriting the generic selenium-playground title. If it's later corrected upstream, the title-based assertions here may need revisiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
